### PR TITLE
vcpkgのパッケージを参照するよう修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,20 +2,14 @@ cmake_minimum_required(VERSION 3.19)
 
 project(SdlWithCMake VERSION 1.0)
 
-include(FetchContent)
+if (DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+    set(CMAKE_TOOLCHAIN_FILE $ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake CACHE STRING "")
+endif()
 
-set(BUILD_SHARED_LIBS OFF)
-FetchContent_Declare(
-    SDL2
-    GIT_REPOSITORY https://github.com/libsdl-org/SDL
-    GIT_TAG release-2.28.1
-)
-FetchContent_MakeAvailable(SDL2)
+find_package(sdl2 CONFIG REQUIRED)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
-
-include_directories(include)
 
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
@@ -23,10 +17,8 @@ add_executable(
     SdlWithCMake
     ${SOURCES}
 )
-target_link_libraries(
-    SdlWithCMake
-    SDL2::SDL2 SDL2::SDL2main
-)
+
+target_link_libraries(SdlWithCMake PRIVATE SDL2::SDL2 SDL2::SDL2main)
 
 add_custom_command(
     TARGET SdlWithCMake POST_BUILD


### PR DESCRIPTION
## 概要
vcpkgのパッケージを参照するよう修正

## 参考URL
[CMakeとvcpkgの連携](https://qiita.com/ryutorion/items/8ed357b8c44d31521327#cmake%E3%81%A8vcpkg%E3%81%AE%E9%80%A3%E6%90%BA)
[Vcpkg+CMakeでのSDL2ビルド](https://ix5231.hateblo.jp/entry/2019/07/21/194127)